### PR TITLE
Avoid black screen when sharing desktop

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ar p teams.deb data.tar.xz | tar -xJf -
+ar p teams.deb data.tar.xz | tar -vxJ --exclude=rect-overlay
 
 mv usr/share/teams .
 


### PR DESCRIPTION
The rect-overlay, i.e. the red border that is painted around around
screen when sharing desktop is causing black screen for users that are
using a bare window manager (such as, i3, awesome, Window Maker,
fluxbox, blackbox, iceWM, etc.).

Exclude rect-overlay from being installed in order to avoid the issue.
It is not a very useful feature anyway and just brings more damage than
benefit.