### PR TITLE
use bsdtar instead of ar to extract the binary deb

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -2,8 +2,11 @@
 
 set -e
 
-ar p teams.deb data.tar.xz | tar -vxJ --exclude=rect-overlay
+bsdtar -Oxf teams.deb 'data.tar.*' |
+  bsdtar -xf - \
+    --strip-components=3 \
+    --exclude='./usr/bin/' \
+    --exclude='./usr/share/applications/' \
+    --exclude='./usr/share/pixmaps/'
 
-mv usr/share/teams .
-
-rm -rf teams.deb usr
+rm -rf teams.deb

--- a/com.microsoft.Teams.json
+++ b/com.microsoft.Teams.json
@@ -114,14 +114,6 @@
             ]
         },
         {
-            "name": "ar",
-            "buildsystem": "simple",
-            "build-commands": [
-                "install -Dm0755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib/",
-                "install -Dm0755 $(which ar) ${FLATPAK_DEST}/bin/"
-            ]
-        },
-        {
             "name": "teams",
             "buildsystem": "simple",
             "build-commands": [

--- a/teams-build.sh
+++ b/teams-build.sh
@@ -2,17 +2,21 @@
 
 set -eux
 
-install -Dm0755 apply_extra.sh ${FLATPAK_DEST}/bin/apply_extra
-install -Dm0755 teams.sh ${FLATPAK_DEST}/bin/teams
-install -Dm0644 ${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+install -Dm0755 apply_extra.sh "${FLATPAK_DEST}/bin/apply_extra"
+install -Dm0755 teams.sh "${FLATPAK_DEST}/bin/teams"
+install -Dm0644 "${FLATPAK_ID}.metainfo.xml" "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
 
-ar p teams.deb data.tar.xz | tar -xJf -
+bsdtar -Oxf teams.deb 'data.tar.*' |
+  bsdtar -xf - \
+    --strip-components=3 \
+    --exclude='./usr/bin/' \
+    --exclude='./usr/share/teams/'
 
-install -Dm0644 usr/share/applications/teams.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-sed -i s:Exec=/usr/bin/teams:Exec=teams: ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-desktop-file-edit --set-key="Icon" --set-value=${FLATPAK_ID} ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+install -Dm0644 applications/teams.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+sed -i s:Exec=/usr/bin/teams:Exec=teams: "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+desktop-file-edit --set-key="Icon" --set-value="${FLATPAK_ID}" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
 
 for size in 64 128 264 512; do
-    convert usr/share/pixmaps/teams.png -resize ${size} ${FLATPAK_ID}.png
-    install -Dm0644 ${FLATPAK_ID}.png ${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png
+    convert pixmaps/teams.png -resize ${size} "${FLATPAK_ID}.png"
+    install -Dm0644 "${FLATPAK_ID}.png" "${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png"
 done

--- a/teams.sh
+++ b/teams.sh
@@ -24,4 +24,4 @@ timezone_workaround()
 
 timezone_workaround
 
-exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/teams/teams "$@"
+exec env TMPDIR="$XDG_CACHE_HOME" zypak-wrapper /app/extra/teams/teams "$@"


### PR DESCRIPTION
- bsdtar is already present in the Runtime
- extract only what's needed
- use a wildcard so the extraction won't fail if the chosen compression type changed

Closes #49