### PR TITLE
Add original parameters to startup script

### DIFF
--- a/teams.sh
+++ b/teams.sh
@@ -24,4 +24,4 @@ timezone_workaround()
 
 timezone_workaround
 
-exec env TMPDIR="$XDG_CACHE_HOME" zypak-wrapper /app/extra/teams/teams "$@"
+exec env TMPDIR="$XDG_CACHE_HOME" zypak-wrapper /app/extra/teams/teams --disable-namespace-sandbox --disable-setuid-sandbox "$@"


### PR DESCRIPTION
The original startup script inside the .deb (/usr/bin/teams) launch the teams binary with these parameters.
Fixes video/camera display issues reported in #69, #70 and #71